### PR TITLE
allow to pass env vars via settings to the phpunit process

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
                     "type": "array",
                     "default": [],
                     "description": "Any phpunit args (phpunit --help)"
+                },
+                "phpunit.envVars": {
+                    "type": "object",
+                    "default": {},
+                    "title": "Set environment variables before running phpunit"
                 }
             }
         },

--- a/src/PhpUnit.ts
+++ b/src/PhpUnit.ts
@@ -69,7 +69,7 @@ export class PhpUnit {
         let phpunitProcess = cp.spawn(
             command,
             this.args,
-            { cwd: workingDirectory.replace(/([\\\/][^\\\/]*\.[^\\\/]+)$/, '') }
+            { cwd: workingDirectory.replace(/([\\\/][^\\\/]*\.[^\\\/]+)$/, ''), env: workspace.getConfiguration('phpunit').envVars }
         );
 
         PhpUnit.currentTest = phpunitProcess;


### PR DESCRIPTION
with this modification you can pass e.g. the `XDEBUG_CONFIG` variable to the php unit process instead of setting this globally on login level.
You can also specify different variables and values on workspace/user level.